### PR TITLE
Add android makefiles and option to exclude data files

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -1,0 +1,1 @@
+include $(call all-subdir-makefiles)

--- a/data/Android.mk
+++ b/data/Android.mk
@@ -1,0 +1,17 @@
+LOCAL_PATH := $(call my-dir)
+
+include $(CLEAR_VARS)
+LOCAL_MODULE := wireless.list
+LOCAL_MODULE_PATH := $(TARGET_OUT)/usr/share/macchanger
+LOCAL_MODULE_TAGS := optional
+LOCAL_MODULE_CLASS := ETC
+LOCAL_SRC_FILES := $(LOCAL_MODULE)
+include $(BUILD_PREBUILT)
+
+include $(CLEAR_VARS)
+LOCAL_MODULE := OUI.list
+LOCAL_MODULE_PATH := $(TARGET_OUT)/usr/share/macchanger
+LOCAL_MODULE_TAGS := optional
+LOCAL_MODULE_CLASS := ETC
+LOCAL_SRC_FILES := $(LOCAL_MODULE)
+include $(BUILD_PREBUILT)

--- a/src/Android.mk
+++ b/src/Android.mk
@@ -1,0 +1,16 @@
+LOCAL_PATH := $(call my-dir)
+
+include $(CLEAR_VARS)
+
+LOCAL_SRC_FILES := \
+	mac.c \
+	maclist.c \
+	netinfo.c \
+	main.c
+
+LOCAL_CFLAGS := -DLISTDIR="\"/system/usr/share/macchanger\"" -DVERSION="\"1.7.0\""
+LOCAL_MODULE := macchanger
+LOCAL_MODULE_PATH := $(TARGET_OUT_OPTIONAL_EXECUTABLES)
+LOCAL_MODULE_TAGS := eng
+
+include $(BUILD_EXECUTABLE)

--- a/src/main.c
+++ b/src/main.c
@@ -197,10 +197,12 @@ main (int argc, char *argv[])
 		}
 	}
 
+#ifndef EXCLUDE_MACLIST
 	/* Read the MAC lists */
 	if (mc_maclist_init() < 0) {
 		exit (EXIT_ERROR);
 	}
+#endif
 
 	/* Print list? */
 	if (print_list) {


### PR DESCRIPTION
Create android makefiles to support building on android. Does expicitly
exclude maclist files as the author was too lazy to figure out how to
correctly supply data files for android package.

Change-Id: I4f807f78a320d28da307eb8b62827b61c554da20
