### PR TITLE
Error message on missing device name.

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -197,6 +197,12 @@ main (int argc, char *argv[])
 		}
 	}
 
+	/* no arguments were processed */
+	if (optind == 1) {
+		print_help();
+		exit (EXIT_ERROR);
+	}
+
 	/* Read the MAC lists */
 	if (mc_maclist_init() < 0) {
 		exit (EXIT_ERROR);
@@ -210,8 +216,8 @@ main (int argc, char *argv[])
 
 	/* Get device name argument */
 	if (optind >= argc) {
-		print_usage();
-		exit (EXIT_OK);
+		fprintf (stderr, "[ERROR] Network device name is required.\n");
+		exit (EXIT_ERROR);
 	}
 	device_name = argv[optind];
 


### PR DESCRIPTION
Output an error message when a command was selected
but the device name is missing. The help message
is still being displayed if no arguments were
provided.

```
$ macchanger 
GNU MAC Changer
Usage: macchanger [options] device

  -h,  --help                   Print this help
  -V,  --version                Print version and exit
  -s,  --show                   Print the MAC address and exit
  -e,  --ending                 Don't change the vendor bytes
  -a,  --another                Set random vendor MAC of the same kind
  -A                            Set random vendor MAC of any kind
  -p,  --permanent              Reset to original, permanent hardware MAC
  -r,  --random                 Set fully random MAC
  -l,  --list[=keyword]         Print known vendors
  -b,  --bia                    Pretend to be a burned-in-address
  -m,  --mac=XX:XX:XX:XX:XX:XX  Set the MAC XX:XX:XX:XX:XX:XX

Report bugs to https://github.com/alobbs/macchanger/issues
```

```
$ macchanger -s
Network device name is required.
```

Not 100% about the error message tho. @alobbs what do you think?

`compile` was also not excluded from git, even though `depcomp` and other autotools artefacts were.
